### PR TITLE
Update haproxy.cfg.j2

### DIFF
--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -39,7 +39,8 @@ defaults
   # Long timeout for WebSocket connections.
   timeout tunnel 1h
 
-listen stats :9000
+listen stats 
+  bind :9000
   mode http
   stats enable
   stats uri /


### PR DESCRIPTION
Inline port definition doesn't work any more